### PR TITLE
Move location .http and Fix routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :orders, defaults: { format: :json }
+  resources :orders
 end

--- a/test.http
+++ b/test.http
@@ -1,1 +1,2 @@
 GET http://localhost:3000/orders
+Accept: application/json


### PR DESCRIPTION
# 변경 사유
api 전송시 routes에서 response type을 json으로 두어야만하는 줄 알음. 하지만 client에서 accept: application/json으로 받고 싶은 데이터 포맷을 정해준다면 respond_to에서 자동으로 json으로 답해줌. 따라서 이를 반영.

# 변경 사항
1. `routes`에서 /orders의 response default값 json인 것을 지움.
2. `.http`에서 accpet: application/json 추가.